### PR TITLE
Added default value to WriteRow function for csv format. This is need…

### DIFF
--- a/formats/csv.go
+++ b/formats/csv.go
@@ -55,6 +55,8 @@ func (f *CsvFormat) WriteRow(values map[string]interface{}) error {
 			} else {
 				record = append(record, "false")
 			}
+		default: 
+			record = append(record, "")
 		}
 	}
 	err := f.writer.Write(record)


### PR DESCRIPTION
…ed when either the column is null in the database or simply the type is not accounted for in the typee switch.