### PR TITLE
Handle nils when exporting CSV data

### DIFF
--- a/formats/csv.go
+++ b/formats/csv.go
@@ -55,6 +55,8 @@ func (f *CsvFormat) WriteRow(values map[string]interface{}) error {
 			} else {
 				record = append(record, "false")
 			}
+		case nil:
+			record = append(record, "")
 		}
 	}
 	err := f.writer.Write(record)


### PR DESCRIPTION
Added a case block to handle nil values - the output for CSV files was
producing incorrect CSV files if some of the columns have nil data.
This leads to misinterpretation of data exported using pgclimb